### PR TITLE
Ignore the height change in the Background component

### DIFF
--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -93,7 +93,7 @@ export default function Background({ children }: Props) {
         clearInterval(cometInterval)
       }
     }
-  }, [width, height])
+  }, [width])
 
   return (
     <Fragment>


### PR DESCRIPTION
When using the site from Google Chrome for Android, the viewport changes when the user scrolls.

Basically, the address bar disappear when the user scrolls down. Apparently, this changes the viewport of the mobile browser and triggers a re-render of the background.