### PR TITLE
Fix background raf loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-portfolio",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/src/main/canvas/Comet.ts
+++ b/src/main/canvas/Comet.ts
@@ -45,6 +45,13 @@ export default class Comet {
   reset() {
     this.x = this.originX * Math.random()
     this.y = this.originY * Math.random()
+    this.setVelocities(
+      //  Velocity of the X axis
+      (Math.random() - 0.5) * (90 - 70) + 70,
+
+      //  Velocity of the Y axis
+      (Math.random() - 0.5) * (9 - 7) + 7
+    )
   }
 
   isVisibleOnScreen(windowWith: number, windowHeight: number) {

--- a/src/main/components/Background.tsx
+++ b/src/main/components/Background.tsx
@@ -61,6 +61,9 @@ export default function Background({ children }: Props) {
       }
     }, 5000)
 
+    //  Store the next raf ref in order to clean it later
+    let raf: number = null
+
     //  Clear the canvas and re-draw every item
     const drawBackground = () => {
       const canvas = canvasRef.current
@@ -72,7 +75,7 @@ export default function Background({ children }: Props) {
       })
       comet.draw(ctx)
 
-      return window.requestAnimationFrame(drawBackground)
+      raf = window.requestAnimationFrame(drawBackground)
     }
 
     if (canvasRef.current) {
@@ -86,7 +89,7 @@ export default function Background({ children }: Props) {
       canvas.style.height = height
       ctx.scale(2, 2)
 
-      const raf = drawBackground()
+      drawBackground()
 
       return () => {
         window.cancelAnimationFrame(raf)

--- a/src/main/components/Background.tsx
+++ b/src/main/components/Background.tsx
@@ -40,7 +40,15 @@ export default function Background({ children }: Props) {
   const { width, height } = useWindowSize()
 
   useEffect(() => {
-    let comet = new Comet(0, height / 2, 0, 0)
+    //  Don't run this effect if the canvas is not ready yet
+    if (!canvasRef.current) return
+
+    const canvas = canvasRef.current
+    const ctx: CanvasRenderingContext2D = canvas.getContext('2d')
+    setUpCanvas(canvas, {
+      width,
+      height,
+    })
 
     //  I want a star every 3px
     const numberOfStarts = Math.floor(width / 3)
@@ -51,12 +59,11 @@ export default function Background({ children }: Props) {
       .map(() => createRandomStar(width, height))
 
     //  Fire a comet every 5 seconds
+    let comet = new Comet(0, height / 2, 0, 0)
     const cometInterval = setInterval(() => {
       if (!comet.isVisibleOnScreen(width, height)) {
-        comet.setVelocities(
-          (Math.random() - 0.5) * (90 - 70) + 70,
-          (Math.random() - 0.5) * (9 - 7) + 7
-        )
+        //  Put comet offscreen and assign
+        //  random velocity
         comet.reset()
       }
     }, 5000)
@@ -66,9 +73,6 @@ export default function Background({ children }: Props) {
 
     //  Clear the canvas and re-draw every item
     const drawBackground = () => {
-      const canvas = canvasRef.current
-      const ctx: CanvasRenderingContext2D = canvas.getContext('2d')
-
       ctx.clearRect(0, 0, canvas.width, canvas.height)
       stars.forEach(star => {
         star.draw(ctx)
@@ -78,23 +82,11 @@ export default function Background({ children }: Props) {
       raf = window.requestAnimationFrame(drawBackground)
     }
 
-    if (canvasRef.current) {
-      const canvas = canvasRef.current
-      const ctx: CanvasRenderingContext2D = canvas.getContext('2d')
+    drawBackground()
 
-      //  Setting canvas for retina displays
-      canvas.width = width * 2
-      canvas.height = height * 2
-      canvas.style.width = width
-      canvas.style.height = height
-      ctx.scale(2, 2)
-
-      drawBackground()
-
-      return () => {
-        window.cancelAnimationFrame(raf)
-        clearInterval(cometInterval)
-      }
+    return () => {
+      window.cancelAnimationFrame(raf)
+      clearInterval(cometInterval)
     }
   }, [width])
 
@@ -104,4 +96,20 @@ export default function Background({ children }: Props) {
       {children}
     </Fragment>
   )
+}
+
+//  Sets the resolution of the canvas for retina display
+function setUpCanvas(
+  canvas: HTMLCanvasElement,
+  opt: {
+    width: number
+    height: number
+  }
+) {
+  const ctx = canvas.getContext('2d')
+  canvas.width = opt.width * 2
+  canvas.height = opt.height * 2
+  canvas.style.width = `${opt.width}`
+  canvas.style.height = `${opt.height}`
+  ctx.scale(2, 2)
 }


### PR DESCRIPTION
This PR fixes #4.

# What was the problem?
Basically the ref to the next `requestAnimationFrame` was not updated. So, when the width was updated, the previous `raf` loop was not dismissed and another one was created.

This was a massive performance problem since it overloaded `raf` queue and, in some cases, delayed the repaint of the browser.

# How has it been fixed?
The solution is to update the `raf` reference on every `requestAnimationFrame`. 